### PR TITLE
Added Final Project link, San Jose urban greenspace portfolio link, corrected personal portfolio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contributors:
 | Juliana Ruef | JulesMRuef | [https://github.com/JulesMRuef] |
 | Nathan Bol | @nbol48 | https://nbol48.github.io/Earthlabnb.github.io/ |
 | Ellen Lamont | ellenalamont17| https://ellenalamont17.github.io/ |
-| Advyth Ramachandran | advythr | https://advythr.github.io/advyth/ |
+| Advyth Ramachandran | advythr | https://advythr.github.io/ |
 | Nathan Bol | @nbol48 | https://Earthlabnb.github.io/ |
 | Agnes Link-Harrington | agneslh | https://agneslh.github.io/ |
 | Peter Kobylarz | peterkobylarz | https://peterkobylarz.github.io/ |

--- a/analysis/final.md
+++ b/analysis/final.md
@@ -18,7 +18,7 @@
 | Taylor O'Brien | taylor-obrien |  |
 | Luca Anna Palasti | lucap1211 |  |
 | Christopher Quinn | cmq879 |  |
-| Advyth Ramachandran | advythr |  |
+| Advyth Ramachandran | advythr | https://github.com/advythr/grassland-phenology-project |
 | Juliana Ruef | JulesMRuef |  |
 | James Smith IV | jsmi374 |  |
 | Megan Smith | megan8617 |  |

--- a/analysis/urban_green_space.md
+++ b/analysis/urban_green_space.md
@@ -17,7 +17,7 @@
 | Taylor O'Brien | taylor-obrien |  |
 | Luca Anna Palasti | lucap1211 |  |
 | Christopher Quinn | cmq879 |  |
-| Advyth Ramachandran | advythr |  |
+| Advyth Ramachandran | advythr | https://advythr.github.io/notebooks/sanjose_greenspace.html |
 | Juliana Ruef | JulesMRuef |  |
 | James Smith IV | jsmi374 |  |
 | Megan Smith | megan8617 |  |


### PR DESCRIPTION
The previous link was broken as I changed the root url. Here I corrected the link for my personal portfolio page.

Update: In this pull request I also added my San Jose urban greenspace portfolio analysis link.

Update2: In this pull request I also added my Final Project submission link.